### PR TITLE
feat(cli): add cursor, pi, and t3code marketplace images

### DIFF
--- a/packages/cli/src/__tests__/do-marketplace.test.ts
+++ b/packages/cli/src/__tests__/do-marketplace.test.ts
@@ -30,7 +30,7 @@ describe("resolveMarketplaceImageSlug", () => {
   });
 
   it("returns undefined for unmapped agents", () => {
-    expect(resolveMarketplaceImageSlug("cursor")).toBeUndefined();
+    expect(resolveMarketplaceImageSlug("not-a-real-agent")).toBeUndefined();
   });
 
   it("returns undefined when SPAWN_DO_FORCE_UBUNTU=1", () => {

--- a/packages/cli/src/digitalocean/digitalocean.ts
+++ b/packages/cli/src/digitalocean/digitalocean.ts
@@ -1056,6 +1056,9 @@ export const MARKETPLACE_IMAGES: Record<string, string> = {
   kilocode: "openrouter-spawnkilocode",
   hermes: "openrouter-spawnhermes",
   junie: "openrouter-spawnjunie",
+  cursor: "openrouter-spawncursor",
+  pi: "openrouter-spawnpi",
+  t3code: "openrouter-spawnt3code",
 };
 
 /** Resolve DO marketplace slug for an agent, honoring opt-out flags. */

--- a/sh/digitalocean/README.md
+++ b/sh/digitalocean/README.md
@@ -89,8 +89,11 @@ Spawn uses DigitalOcean 1-click marketplace images when a slug is available. The
 | kilocode | `openrouter-spawnkilocode` |
 | hermes | `openrouter-spawnhermes` |
 | junie | `openrouter-spawnjunie` |
+| cursor | `openrouter-spawncursor` |
+| pi | `openrouter-spawnpi` |
+| t3code | `openrouter-spawnt3code` |
 
-Agents without a marketplace mapping (e.g. `cursor`, `pi`, `t3code`) use Ubuntu 24.04 with cloud-init and a full agent install.
+Agents without a marketplace mapping use Ubuntu 24.04 with cloud-init and a full agent install.
 
 To force a fresh Ubuntu install for testing or E2E:
 


### PR DESCRIPTION
Follow-up to #3453. Adds the three agents that were missing from the marketplace image map.

`cursor`, `pi`, and `t3code` had no vendor-portal listing, so the nightly `packer-snapshots` job built and region-transferred their snapshots but skipped submission:

```
digitalocean/cursor  No marketplace app ID for agent cursor — skipping
```

Listings now exist for all three and their app IDs are in `MARKETPLACE_APP_IDS`. Verified by targeted workflow runs — each reaches the vendor API and returns `400 App already pending review`, the expected response while a listing is in review: [cursor](https://github.com/OpenRouterLabs/spawn/actions/runs/30662054745), [pi](https://github.com/OpenRouterLabs/spawn/actions/runs/30662059015), [t3code](https://github.com/OpenRouterLabs/spawn/actions/runs/30662063668).

## What changed

- `MARKETPLACE_IMAGES` — three entries
- `sh/digitalocean/README.md` — three table rows, and the sentence naming these agents as unmapped is no longer true
- `do-marketplace.test.ts` — the unmapped-agent test used `cursor`, which is now mapped, so it asserts on a name that is actually unmapped

## How I verified

- `bun test` — 2283 pass, 0 fail
- `biome check` / `lint` — clean

## Merge timing

All ten listings are in DigitalOcean's review queue. Until review clears, these three slugs do not resolve, and droplet creation fails with no fallback — so this should land after approval, not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
